### PR TITLE
minor improvement for heist related

### DIFF
--- a/FollowTask.cs
+++ b/FollowTask.cs
@@ -41,7 +41,7 @@ namespace FollowBot
         public async Task<bool> Run()
         {
             if (!FollowBotSettings.Instance.ShouldFollow) return false;
-            if (!LokiPoe.IsInGame || LokiPoe.Me.IsDead || LokiPoe.Me.IsInTown || LokiPoe.Me.IsInHideout)
+            if (!LokiPoe.IsInGame || LokiPoe.Me.IsDead || LokiPoe.Me.IsInTown || LokiPoe.Me.IsInHideout || World.CurrentArea.Id == "HeistHub")
             {
                 return false;
             }

--- a/TravelToPartyZoneTask.cs
+++ b/TravelToPartyZoneTask.cs
@@ -60,7 +60,12 @@ namespace FollowBot
                 {
                     if (FollowBotSettings.Instance.DontPortOutofMap) return false;
                 }
-
+                //check for different rouge harbour
+                if(leader.PlayerEntry.Area.Id == "HeistHub" && LokiPoe.CurrentWorldArea.Id == "HeistHub")
+                {
+                    //GlobalLog.Warn($"in differwnt harbour with  {leadername} ");
+                    return true;
+                }
                 _zoneCheckRetry ++;
                 if (_zoneCheckRetry < 3)
                 {
@@ -96,15 +101,20 @@ namespace FollowBot
                 FollowBot.Leader = null;
                 return true;
             }
-            //Next check for Heist portals:
+            //Next check for Heist entry portals:
             var heistportal = LokiPoe.ObjectManager.GetObjectByMetadata("Metadata/Terrain/Leagues/Heist/Objects/MissionEntryPortal");
+            //also check for heist exit portal
+            if (heistportal == null)
+            {
+                heistportal = LokiPoe.ObjectManager.GetObjectByMetadata("Metadata/Terrain/Leagues/Heist/Objects/MissionExitPortal");
+            }
+            //if we found portal 
             if (heistportal != null && heistportal.Components.TargetableComponent.CanTarget)
             {
                 Log.DebugFormat("[{0}] Found walkable heist portal.", Name);
                 if (LokiPoe.Me.Position.Distance(heistportal.Position) > 20)
                 {
                     var walkablePosition = ExilePather.FastWalkablePositionFor(heistportal, 20);
-
                     // Cast Phase run if we have it.
                     FollowBot.PhaseRun();
 


### PR DESCRIPTION
-follower should not follow in rouge harbour
-in case both leader and follower is in rouge harbour but different instance, follower should not teleport to reduce follower movement in rouge harbour
-check for heist exit portal instead of teleport out to reduce follower movement in rouge harbour